### PR TITLE
WIP: go install not working

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module "github.com/jakexks/go-providence-checker"
+module github.com/jakexks/go-providence-checker


### PR DESCRIPTION
The module is not installable, not sure why:

 ```
% go install github.com/jakexks/go-providence-checker@main
go install github.com/jakexks/go-providence-checker@main:
    module github.com/jakexks/go-providence-checker@main found
    (v0.0.0-20210127121906-b08ba766bc2d), but does not contain
    package github.com/jakexks/go-providence-checker
```